### PR TITLE
Add minDocFreq and minTotalFreq request parameters

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/action/termlist/TermlistRequest.java
+++ b/src/main/java/org/xbib/elasticsearch/action/termlist/TermlistRequest.java
@@ -30,6 +30,10 @@ public class TermlistRequest extends BroadcastOperationRequest<TermlistRequest> 
 
     private boolean sortByTotalFreq;
 
+    private int minDocFreq = 1;
+
+    private int minTotalFreq = 1;
+
     TermlistRequest() {
     }
 
@@ -91,6 +95,22 @@ public class TermlistRequest extends BroadcastOperationRequest<TermlistRequest> 
 
     public boolean sortByTotalFreq() {
         return sortByTotalFreq;
+    }
+
+    public int getMinDocFreq() {
+        return minDocFreq;
+    }
+
+    public void setMinDocFreq(int minDocFreq) {
+        this.minDocFreq = minDocFreq;
+    }
+
+    public int getMinTotalFreq() {
+        return minTotalFreq;
+    }
+
+    public void setMinTotalFreq(int minTotalFreq) {
+        this.minTotalFreq = minTotalFreq;
     }
 
     static TermlistRequest from(StreamInput in) throws IOException {

--- a/src/main/java/org/xbib/elasticsearch/action/termlist/TransportTermlistAction.java
+++ b/src/main/java/org/xbib/elasticsearch/action/termlist/TransportTermlistAction.java
@@ -160,10 +160,10 @@ public class TransportTermlistAction
                             BytesRef text;
                             while ((text = termsEnum.next()) != null) {
                                 // skip invalid terms
-                                if (termsEnum.docFreq() < 1) {
+                                if (termsEnum.docFreq() < request.getRequest().getMinDocFreq()) {
                                     continue;
                                 }
-                                if (termsEnum.totalTermFreq() < 1) {
+                                if (termsEnum.totalTermFreq() < request.getRequest().getMinTotalFreq()) {
                                     continue;
                                 }
                                 // docFreq() = the number of documents containing the current term

--- a/src/main/java/org/xbib/elasticsearch/rest/action/termlist/RestTermlistAction.java
+++ b/src/main/java/org/xbib/elasticsearch/rest/action/termlist/RestTermlistAction.java
@@ -43,6 +43,8 @@ public class RestTermlistAction extends BaseRestHandler {
             termlistRequest.sortByDocFreq(request.paramAsBoolean("sortbydocfreqs", false));
             termlistRequest.sortByTotalFreq(request.paramAsBoolean("sortbytotalfreqs", false));
             termlistRequest.sortByTerm(request.paramAsBoolean("sortbyterms", false));
+            termlistRequest.setMinDocFreq(request.paramAsInt("minDocFreq", 1));
+            termlistRequest.setMinTotalFreq(request.paramAsInt("minTotalFreq", 1));
             final long t0 = System.nanoTime();
             client.execute(TermlistAction.INSTANCE, termlistRequest, new RestBuilderListener<TermlistResponse>(channel) {
                 @Override


### PR DESCRIPTION
I added two request parameters, minDocFreq and minTotalFreq that only return those terms that are over those thresholds. This was needed in my case to limit the number of the output terms on large indices in order to avoid OutOfMemoryErrors, as I was interested in the most popular terms only.